### PR TITLE
fix total price error, to only add price of items in cart

### DIFF
--- a/src/components/Cart/Cart.js
+++ b/src/components/Cart/Cart.js
@@ -69,7 +69,6 @@ const Cart = props => {
                                 <span className="cart__list-ul-item-amount">
                                   <button
                                     disabled={
-                                      
                                       consumer.products[productKey].count === 1
                                     }
                                     onClick={() =>
@@ -127,6 +126,7 @@ const Cart = props => {
                                 return details.count * details.price;
                               })
                               .reduce((prev, current) => {
+                                console.log(current + prev);
                                 return prev + current;
                               }, 0);
                             return totalSum;

--- a/src/context.js
+++ b/src/context.js
@@ -41,6 +41,7 @@ class ProductProvider extends Component {
       cartNumber = cartNumber + 1;
 
       products[clickedWatch].inCart = true;
+      products[clickedWatch].count += 1;
       //Update cartNumber
       this.setState({
         products,


### PR DESCRIPTION
Loop for calculating the total price was going through the whole list of products and not just the items in the cart. This pull request fixes that.